### PR TITLE
Image not loading on desktop Fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
 
             <div class="project-image-container">
               <img
-                src="/assets/images/thumbnail-project-1-large.webp"
+                src="assets/images/thumbnail-project-1-large.webp"
                 alt="project-img"
               />
               <div class="project-button-container">
@@ -162,7 +162,7 @@
 
             <div class="project-image-container">
               <img
-                src="/assets/images/thumbnail-project-2-large.webp"
+                src="assets/images/thumbnail-project-2-large.webp"
                 alt="project-img"
               />
               <div class="project-button-container">
@@ -190,7 +190,7 @@
 
             <div class="project-image-container">
               <img
-                src="/assets/images/thumbnail-project-3-large.webp"
+                src="assets/images/thumbnail-project-3-large.webp"
                 alt="project-img"
               />
               <div class="project-button-container">
@@ -219,7 +219,7 @@
 
             <div class="project-image-container">
               <img
-                src="/assets/images/thumbnail-project-4-large.webp"
+                src="assets/images/thumbnail-project-4-large.webp"
                 alt="project-img"
               />
               <div class="project-button-container">
@@ -248,7 +248,7 @@
 
             <div class="project-image-container">
               <img
-                src="/assets/images/thumbnail-project-5-large.webp"
+                src="assets/images/thumbnail-project-5-large.webp"
                 alt="project-img"
               />
               <div class="project-button-container">
@@ -277,7 +277,7 @@
 
             <div class="project-image-container">
               <img
-                src="/assets/images/thumbnail-project-6-large.webp"
+                src="assets/images/thumbnail-project-6-large.webp"
                 alt="project-img"
               />
               <div class="project-button-container">


### PR DESCRIPTION
The ```src``` of the images used an absolute path ```/assets/images/*``` which means that it specifies the full URL or file path starting from the root directory of the web server.  Which in this case does not exist. 
Whereas after removing the ```/``` before the ```assets``` folder makes it a relative path ```assets/images/*``` so it specifies the file path relative to the location of the HTML file and thus we are able to fetch the images even after hosting the website.

